### PR TITLE
ci removed from branches except master

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,10 @@
 name: master
 
-on: push
-
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [master]
 env:
   NODE_VERSION: 14
   FORCE_COLOR: 3


### PR DESCRIPTION
- Currently CI is running on all branches, ideally it should run on master only.
- This pr merge will trigger ci only when code is added to master branch