### PR TITLE
Lock to @solana/web3.js 1.x for compatibility

### DIFF
--- a/src/pages/guides/openlogin-solana.md
+++ b/src/pages/guides/openlogin-solana.md
@@ -38,7 +38,7 @@ library to derive ED25519 key which is compatible with solana.
 ```shell
 npm install --save @toruslabs/openlogin
 npm install --save @toruslabs/openlogin-ed25519
-npm install --save @solana/web3.js
+npm install --save @solana/web3.js@1
 ```
 
 ## Initialize solana web3 connection


### PR DESCRIPTION

Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498